### PR TITLE
Connection pool

### DIFF
--- a/internal/bot/discord.go
+++ b/internal/bot/discord.go
@@ -60,8 +60,7 @@ func main() {
 		log.Error("error opening connection", err)
 	}
 
-	// Shut down bot when there is CTRL-C or OS interruption
-	defer bot.Close()
+
 
 	// Wait here until CTRL-C or other term signal is received
 	log.Info("Bot is now running. Press CTRL+C to exit.")
@@ -70,6 +69,15 @@ func main() {
 	<-stop
 
 	log.Info("Shutting down...")
+
+	// when CTRL-C or OS interruption
+	db := database.GetDatabaseInstance()
+	// (1) first close database
+	if (db != nil) {
+		db.Close()
+	}
+	// (2) than close bot
+	bot.Close()
 }
 
 /*
@@ -189,7 +197,9 @@ func onGuildRemove(s *discordgo.Session, event *discordgo.GuildDelete) {
 
 	// Connecting to oracle database
 	oracleClient := database.GetDatabaseInstance()
-	defer oracleClient.Close()
+	
+	// removed defer, because connection pools are not meant to close
+	// instead moved a defer function to the main method
 
 	var guildID string = event.Guild.ID
 	if err := oracleClient.DeleteServer(guildID); err != nil {

--- a/internal/bot/discord.go
+++ b/internal/bot/discord.go
@@ -60,7 +60,8 @@ func main() {
 		log.Error("error opening connection", err)
 	}
 
-
+	// Shut down bot when there is CTRL-C or OS interruption
+	defer bot.Close()
 
 	// Wait here until CTRL-C or other term signal is received
 	log.Info("Bot is now running. Press CTRL+C to exit.")
@@ -70,14 +71,6 @@ func main() {
 
 	log.Info("Shutting down...")
 
-	// when CTRL-C or OS interruption
-	db := database.GetDatabaseInstance()
-	// (1) first close database
-	if (db != nil) {
-		db.Close()
-	}
-	// (2) than close bot
-	bot.Close()
 }
 
 /*

--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -66,6 +66,11 @@ func newDatabaseService() (ChannelsDB, error) {
 		return nil, errors.Wrap(err, "Couldn't connect to oracle database!")
 	}
 
+	// set up connection pool
+	conn.SetMaxOpenConns(10) // max number of open connections allowed
+	conn.SetMaxIdleConns(5) // max number of idle connections allowed
+	conn.SetConnMaxLifetime(time.Hour) // life cycle of a connection (an hour)
+
 	return &Database{conn: conn}, nil
 }
 

--- a/internal/database/database_pool_test.go
+++ b/internal/database/database_pool_test.go
@@ -1,0 +1,18 @@
+package database
+
+import (
+	"ColorStack-Discord-Bot/internal/types"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// this function tests if the same instance is being returned which should happen if connection pooling works correctly
+func TestConnectionPooling(t *testing.T) {
+	db1 = GetDatabaseInstance()
+	db2 = GetDatabaseInstance()
+
+	if (db1 != db2) {
+		t.Errorf("The instance of the databases are not the same, pooling does not work")
+	}
+}	


### PR DESCRIPTION
 introduces connection pooling for the Oracle database used by the bot.

- Set up connection pool parameters:
- SetMaxOpenConns(10)
-  SetMaxIdleConns(5)
- SetConnMaxLifetime(time.Hour)

Also alternated to not close the database until the end of the main method is discord.go as to not shut down the connection pooling until the bot is shut down.